### PR TITLE
Display the names of previous levels in 'Level List' view

### DIFF
--- a/hunt/levels.py
+++ b/hunt/levels.py
@@ -141,7 +141,11 @@ def list_levels(request: AuthenticatedHttpRequest) -> str:
     user = request.user
     team_level = max_level() if user.is_staff else user.huntinfo.level
 
-    levels = list(range(1, team_level + 1))
+    levels = []
+    for level_id in range(1, team_level):
+        levels.append({"id": level_id, "name": Level.objects.get(number=level_id).name})
+    levels.append({"id": team_level, "name": "Current Level"})
+
     template = loader.get_template("levels.html")
     context = {"team_level": team_level, "levels": levels}
 

--- a/hunt/templates/levels.html
+++ b/hunt/templates/levels.html
@@ -3,10 +3,10 @@
 <h1>Unlocked Levels</h1>
 <div class="level-list">
   {% for level in levels %}
-  <a class="gobutton" href="/level/{{ level }}">
+  <a class="gobutton" href="/level/{{ level.id }}">
     <div style="display: flex">
       <div class="level-label">LEVEL</div>
-      {{ level }}
+      {{ level["id"] }} - {{ level["name"] }}
     </div>
   </a>
   {% endfor %}

--- a/hunt/templates/levels.html
+++ b/hunt/templates/levels.html
@@ -3,10 +3,10 @@
 <h1>Unlocked Levels</h1>
 <div class="level-list">
   {% for level in levels %}
-  <a class="gobutton" href="/level/{{ level.id }}">
+  <a class="gobutton" href="/level/{{ level['id'] }}">
     <div style="display: flex">
       <div class="level-label">LEVEL</div>
-      {{ level["id"] }} - {{ level["name"] }}
+      {{ level['id'] }}: {{ level['name'] }}
     </div>
   </a>
   {% endfor %}


### PR DESCRIPTION
I've not tested this- and am certainly not proposing we use this this hunt -  but WIBNI the Level List view gave you the names of levels for easier navigation. 