### PR TITLE
chat styling tweaks.

### DIFF
--- a/hunt/static/style.css
+++ b/hunt/static/style.css
@@ -126,6 +126,17 @@ body {
   align-items: center;
 }
 
+.chat-container {
+  max-width: 100%;
+}
+
+.chat-messages {
+  max-height: 300px;
+  overflow-y: scroll;
+  text-align: left;
+  overflow-wrap: anywhere;
+}
+
 .heading {
   padding: 0 5vw;
   display: flex;

--- a/hunt/templates/room.html
+++ b/hunt/templates/room.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<div class="container">
+<div class="container chat-container">
   <div class="columns is-multiline">
     <div class="column is-full">
       <section class="hero is-primary">
@@ -12,7 +12,7 @@
 
     <div class="column is-full">
       <div class="box">
-        <div id="chat-messages" style="max-height: 300px; overflow-y: scroll;">
+        <div id="chat-messages" class="chat-messages">
             {% for message in messages %}
             <b>{{ message.name }}</b>: {{ message.content }}<br>
             {% endfor %}


### PR DESCRIPTION
CSS styling tweaks to improve the chat experience (especially on mobile).

Prior to this change, long strings, e.g. URLs caused the chat container to grow wider than the screen, with no way to see the content off the screen.  max-width, prevents this.  The addition of the overflow-wrap setting, means that long strings (e.g. URLs) are fully visible (split over multiple lines)

Left aligned the text to make it easier to read (IMO).

<img width="286" alt="image" src="https://github.com/dimbleby/e-treasure-hunt/assets/55300796/ba6fc3cc-c88e-4c98-a266-100d4d1e1e88">

Also includes a benign refactor to move styling from HTML to CSS.