### PR TITLE
Fix deprecated taint comment and increase SECRET_KEY length

### DIFF
--- a/azure/main.tf
+++ b/azure/main.tf
@@ -29,7 +29,7 @@ provider "azurerm" {
 }
 
 # NB force new password by:
-# terraform taint random_password.azuread_password
+# terraform apply -replace=random_password.azuread_password
 resource "random_password" "azuread_password" {
   length      = 16
   min_lower   = 1
@@ -217,7 +217,7 @@ resource "azurerm_service_plan" "treasure" {
 }
 
 resource "random_password" "secret_key" {
-  length      = 16
+  length      = 50
   min_lower   = 1
   min_upper   = 1
   min_numeric = 1


### PR DESCRIPTION
- Replace 'terraform taint' with 'terraform apply -replace' (taint deprecated since Terraform 1.5)
- Increase Django SECRET_KEY from 16 to 50 characters per Django docs